### PR TITLE
Prevent a TypeError Exception

### DIFF
--- a/sphinxcontrib/plantuml.py
+++ b/sphinxcontrib/plantuml.py
@@ -376,7 +376,8 @@ def _convert_eps_to_pdf(self, refname, fname):
     try:
         try:
             p = subprocess.Popen(args, stdout=subprocess.PIPE,
-                                 stderr=subprocess.PIPE)
+                                 stderr=subprocess.PIPE,
+                                 encoding='utf-8')
         except OSError as err:
             # workaround for missing shebang of epstopdf script
             if err.errno != getattr(errno, 'ENOEXEC', 0):


### PR DESCRIPTION
Under my Python 3.6.6 env I get a:

```
TypeError: must be str, not bytes
```
without this fix.