### PR TITLE
Bump to Sphinx>=1.6, which introduced sphinx.util.logging.getLogger

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 long_desc = open('README.rst').read()
 
-requires = ['Sphinx>=1.1']
+requires = ['Sphinx>=1.6']
 
 setup(
     name='sphinxcontrib-plantuml',


### PR DESCRIPTION
`sphinx.util.logging.getLogger` was added in Sphinx 1.6.
Its usage was added in `sphinxcontrib-plantuml` latest release (0.16).

Bumping the lower bound will help for tools like `pip-tools`, `pip check`,
and other dependency management tools.