### PR TITLE
Implement 'name' option

### DIFF
--- a/sphinxcontrib/plantuml.py
+++ b/sphinxcontrib/plantuml.py
@@ -93,6 +93,7 @@ class UmlDirective(Directive):
         'height': directives.length_or_unitless,
         'html_format': html_format,
         'latex_format': latex_format,
+        'name': directives.unchanged,
         'scale': directives.percentage,
         'width': directives.length_or_percentage_or_unitless,
     }
@@ -134,6 +135,7 @@ class UmlDirective(Directive):
             caption_node.extend(messages)
             set_source_info(self, caption_node)
             node += caption_node
+        self.add_name(node)
         if 'html_format' in self.options:
             node['html_format'] = self.options['html_format']
         if 'latex_format' in self.options:

--- a/sphinxcontrib/plantuml.py
+++ b/sphinxcontrib/plantuml.py
@@ -88,13 +88,13 @@ class UmlDirective(Directive):
     optional_arguments = 1
     option_spec = {
         'alt': directives.unchanged,
+        'align': align,
         'caption': directives.unchanged,
         'height': directives.length_or_unitless,
-        'width': directives.length_or_percentage_or_unitless,
-        'scale': directives.percentage,
-        'align': align,
         'html_format': html_format,
         'latex_format': latex_format,
+        'scale': directives.percentage,
+        'width': directives.length_or_percentage_or_unitless,
     }
 
     def run(self):

--- a/tests/fixture/README.rst
+++ b/tests/fixture/README.rst
@@ -1,7 +1,7 @@
 tests/fixture
 =============
 
-Files under `testx/fixture` are used by `test_functional.py`.
+Files under `tests/fixture` are used by `test_functional.py`.
 `test_functional.py` runs sphinx.build with *fake* plantuml executable,
 `fakecmd.py`.
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -139,6 +139,18 @@ def test_buildhtml_caption():
             in readfile('index.html'))
 
 @with_runsphinx('html')
+def test_buildhtml_name():
+    """Generate HTML with name specified
+
+    .. uml::
+       :caption: Caption
+       :name: label
+
+       Hello
+    """
+    assert b'<div class="figure" id="label">' in readfile('index.html')
+
+@with_runsphinx('html')
 def test_buildhtml_nonascii():
     u"""Generate simple HTML of non-ascii diagram
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,33 +1,8 @@
-## configuration for tox <http://codespeak.net/tox/>
-
-## tox automates running certain tasks within virtualenvs.  The following
-## tox configuration outlines a basic setup for running unit tests and
-## building sphinx docs in separate virtual environments.  Give it a try!
-
 [tox]
-envlist=python,doc
+envlist = py27
 
-# test running
-[testenv:python]
-deps=
-    ## if you use nose for test running
+[testenv]
+deps =
     nose
-    ## if you use py.test for test running
-    # py
     rst2pdf
-commands=
-    ## run tests with py.test
-    # py.test []
-    ## run tests with nose
-    nosetests []
-
-[testenv:doc]
-deps=
-    sphinx
-    # add all Sphinx extensions and other dependencies required to build your docs
-commands=
-    ## test links
-    # sphinx-build -W -b linkcheck -d {envtmpdir}/doctrees doc {envtmpdir}/linkcheck
-    ## test html output
-    # sphinx-build -W -b html -d {envtmpdir}/doctrees doc {envtmpdir}/html
-
+commands = nosetests


### PR DESCRIPTION
This PR fixes some issues with running tox and implements 'name' option for 'uml' directive. It adds test for this directive. Fixes #39.