### PR TITLE
Adds FTP mode support for PlantUML

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,3 +92,23 @@ plantuml_epstopdf
 
 plantuml_syntax_error_image
   Should plantuml generate images with render errors. (default: False)
+
+plantuml_use_ftp_mode
+  Starts a local FTP server provided by plantuml. (default: False)
+  Can reduce generation time by ~60%, if many plantuml diagrams shall to be generated.
+  For more details see: https://plantuml.com/ftp
+
+  **Important**: Does not support output format `svg` for `plantuml_output_format`. `svg_img` and `svg_obj`
+  are supported.
+
+plantuml_ftp_port
+   Custom port, which is used to start and connect to the plantuml FTP server. (default: 4242)
+
+plantuml_ftp_url
+   URL to use for connecting to a plantuml FTP server. (default: '127.0.0.1')
+   If set, `plantuml_spawn_ftp_server` should be set to `False`.
+
+plantuml_spawn_ftp_server
+    Indicates, if a local FTP server shall be started during build. Or if an external instance is used.
+    (default: True).
+    If set to `False`, `plantuml_ftp_url` should also be set.

--- a/tests/fakecmd.py
+++ b/tests/fakecmd.py
@@ -2,6 +2,6 @@
 import sys
 
 # embed as PostScript comment
-print '%', ' '.join(sys.argv)
+print('%', ' '.join(sys.argv))
 for line in sys.stdin:
     sys.stdout.write('% ' + line)

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -148,7 +148,8 @@ def test_buildhtml_name():
 
        Hello
     """
-    assert b'<div class="figure" id="label">' in readfile('index.html')
+    # assert b'<div class="figure" id="label">' in readfile('index.html')
+    assert b'<div class="figure align-default" id="label">' in readfile('index.html')
 
 @with_runsphinx('html')
 def test_buildhtml_nonascii():
@@ -270,3 +271,72 @@ def test_buildpdf_simple():
     epscontent = readfile(epsfiles[0]).splitlines()
     assert b'-teps' in epscontent[0]
     assert_equals(b'Hello', epscontent[1][2:])
+
+
+@with_runsphinx('html', plantuml_use_ftp_mode=True, plantuml='plantuml')
+def test_buildhtml_simple_with_ftp_support_for_png():
+    """Generate simple HTML
+
+    .. uml::
+
+       @startuml
+       a -> b
+       b -> c
+       c --> a
+       @enduml
+
+    .. uml::
+
+       @startuml
+       x -> y
+       y -> z
+       z --> x
+       @enduml
+    """
+    assert readfile('index.html').count(b'<img src="_images/plantuml') == 2
+
+
+@with_runsphinx('html', plantuml_use_ftp_mode=True, plantuml='plantuml', plantuml_output_format='svg_img')
+def test_buildhtml_simple_with_ftp_support_for_svg_img():
+    """Generate simple HTML
+
+    .. uml::
+
+       @startuml
+       a -> b
+       b -> c
+       c --> a
+       @enduml
+
+    .. uml::
+
+       @startuml
+       x -> y
+       y -> z
+       z --> x
+       @enduml
+    """
+    assert readfile('index.html').count(b'<img src="_images/plantuml') == 2
+
+
+@with_runsphinx('html', plantuml_use_ftp_mode=True, plantuml='plantuml', plantuml_output_format='svg_obj')
+def test_buildhtml_simple_with_ftp_support_for_svg_obj():
+    """Generate simple HTML
+
+    .. uml::
+
+       @startuml
+       a -> b
+       b -> c
+       c --> a
+       @enduml
+
+    .. uml::
+
+       @startuml
+       x -> y
+       y -> z
+       z --> x
+       @enduml
+    """
+    assert readfile('index.html').count(b'<object data="_images/plantuml') == 2


### PR DESCRIPTION
Allows to use the FTP mode from PlantUML.
This avoids the startup of the JAVA RTE for each diagram generation, which may speed up the overall build process if many files need to be generated.

It is the first shot, so it may not be perfect.

Content:
* FTP mode feature
* Tests for FTP mode 
* Updated docs / README for FTP mode config vars
* Fixed test case. At least on my system it failed. Maybe because of a new Sphinx version and there a changed HTML output.

Known problems:
* Output format `svg` is not supported, because this format needs to generate svg and png. But the PlantUML FTP server can only handle one fix format after start up. So we would need to spawn two instances of it.
Doable, but I'm not sure if this extra level of complexity is really needed only for "svg" output.
`svg_img` and `svg_obj` are supported!
* For tests I needed to implement `time.sleep(0.5)` in some situations. Otherwise start up and termination of the server may get in conflict, if tests are fired to quickly for the system.
But it doesn't affect the overall diagram generation time. So in worst case it costs <=1 sec of extra build time.
* Not tested on windows or mac!

Fixes #44