### PR TITLE
Support max-width option in tikz output

### DIFF
--- a/sphinxcontrib/plantuml.py
+++ b/sphinxcontrib/plantuml.py
@@ -651,6 +651,13 @@ def _latex_adjustbox_options(self, node):
     if 'scale' in node:
         if not adjustbox_options:
             adjustbox_options.append('scale=%s' % (float(node['scale']) / 100.0))
+    if 'max-width' in node:
+        if 'scale' in node:
+            w = self.latex_image_length(node['max-width'], node['scale'])
+        else:
+            w = self.latex_image_length(node['max-width'])
+        if w:
+            adjustbox_options.append('max width=%s' % w)
     return adjustbox_options
 
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -309,6 +309,19 @@ def test_buildlatex_simple_height_with_tikz():
                      readfile('plantuml_fixture.tex'))
 
 
+@with_runsphinx('latex', plantuml_latex_output_format='tikz')
+def test_buildlatex_simple_max_width_with_tikz():
+    """Generate simple LaTeX with TikZ
+
+    .. uml::
+       :max-width: 50mm
+
+       Hello
+    """
+    assert re.search(br'\\adjustbox\{max width=50mm\}\{\\input\{+plantuml-',
+                     readfile('plantuml_fixture.tex'))
+
+
 @with_runsphinx('latex', plantuml_latex_output_format='pdf')
 def test_buildlatex_simple_with_pdf():
     """Generate simple LaTeX with PDF


### PR DESCRIPTION
### Problem
When creating large diagrams using plantuml, they can quickly get too wide for a pdf page.
For images in the png, pdf and svg format, this problem is handled by the sphinx-provided "sphinxincludegraphics" latex command, which resizes the included graphic if needed.
As tikz images are embedded using the "\input" command, this resize logic is not applicable for them.

### Solution
I would suggest to use the "max-width" option (which is already somehow implemented but not documented) to allow the user to specify a maximum width.
The "adjustbox" macro, which is already being used for giving an absolute size for an image, also supports this type of maximum size.
This way, the image is not resized if it fits, but only if it would exceed the given size.