### PR TITLE
Use SVG format for generating images to embed into the RST prior to rst2pdf creating a PDF

### DIFF
--- a/sphinxcontrib/plantuml.py
+++ b/sphinxcontrib/plantuml.py
@@ -758,8 +758,7 @@ def text_visit_plantuml(self, node):
 def pdf_visit_plantuml(self, node):
     _render_batches_on_vist(self)
     try:
-        refname, outfname = render_plantuml(self, node, 'eps')
-        refname, outfname = _convert_eps_to_pdf(self, refname, outfname)
+        _, outfname = render_plantuml(self, node, 'svg')
     except PlantUmlError as err:
         logger.warning(str(err), location=node, type='plantuml')
         raise nodes.SkipNode


### PR DESCRIPTION
The original code would generate an EPS and PDF file for each PlantUML and them embed them as PDFs into the RST before processing through rst2pdf to generate the PDF. However, rst2pdf doesn't appear to support PDFs embedded as images into the RST.
So, changing to SVG.

Unless someone can show me how to get the PDF to work with rst2pdf. I tried it directly and it wouldn't take it.