### PR TITLE
Document text output for PlantUML in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,6 +127,17 @@ plantuml_batch_size
 
   To enable batch rendering, set the size to 100-1000.
 
+Text output
+-----------
+
+When using Sphinx's ``text`` builder, PlantUML diagrams are rendered as
+text diagrams. The configured PlantUML command needs to forward
+command-line arguments for that option, so a wrapper script, as
+mentioned above in the Usage section, with ``"$@"`` must be used.
+
+The ``plantuml_output_format`` setting only controls HTML output and
+does not affect the text builder.
+
 Developing
 ----------
 

--- a/README.rst
+++ b/README.rst
@@ -135,9 +135,6 @@ text diagrams. The configured PlantUML command needs to forward
 command-line arguments for that option, so a wrapper script, as
 mentioned above in the Usage section, with ``"$@"`` must be used.
 
-The ``plantuml_output_format`` setting only controls HTML output and
-does not affect the text builder.
-
 Developing
 ----------
 


### PR DESCRIPTION
## Summary

Document how PlantUML diagrams are handled by Sphinx’s `text` builder.

The extension invokes the configured PlantUML command with `-ttxt`. Wrapper scripts must therefore forward command-line arguments, as the existing wrapper example does with `"$@"`.

The issue was discovered in https://github.com/orgs/sphinx-doc/discussions/14557